### PR TITLE
Important modification at line 116

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/FolderId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/FolderId.java
@@ -111,8 +111,9 @@ public final class FolderId extends ServiceId {
   public void writeAttributesToXml(EwsServiceXmlWriter writer)
       throws ServiceXmlSerializationException {
     if (this.getFolderName() != null) {
+      // this line is modified due to differences between the letters "i" and "I" in the Turkish language
       writer.writeAttributeValue(XmlAttributeNames.Id, this
-          .getFolderName().toString().toLowerCase());
+          .getFolderName().toString().toLowerCase(Locale.ENGLISH));
 
       if (this.mailbox != null) {
         try {


### PR DESCRIPTION
The letter "i" in uppercase is written as the uppercase "ı" in the Turkish keyboard. When _WellKnownFolderName_ is called with any word that contains "i", the program crashes. To prevent "inbox" from becoming "ınbox", "**Locale.ENGLISH**" is passed as a parameter to function **toLowerCase()**.